### PR TITLE
Compiling kvm-unit-tests framework as library with edk2 for bsa-acs

### DIFF
--- a/lib/acpi.h
+++ b/lib/acpi.h
@@ -1,5 +1,5 @@
-#ifndef _ACPI_H_
-#define _ACPI_H_
+#ifndef _ACPI_H_LITMUS
+#define _ACPI_H_LITMUS
 
 #include "libcflat.h"
 

--- a/lib/arm/io.c
+++ b/lib/arm/io.c
@@ -11,7 +11,11 @@
 #include <libcflat.h>
 #include <devicetree.h>
 #include <chr-testdev.h>
+#ifndef BSA_ACS
 #include <config.h>
+#else
+#define CONFIG_UART_EARLY_BASE 0x09000000
+#endif
 #include <asm/psci.h>
 #include <asm/spinlock.h>
 #include <asm/io.h>

--- a/lib/arm/setup.c
+++ b/lib/arm/setup.c
@@ -327,6 +327,12 @@ static efi_status_t efi_mem_init(efi_bootinfo_t *efi_bootinfo)
 	efi_memory_desc_t *d = NULL;
 	phys_addr_t base, top;
 	struct mem_region r;
+#ifdef BSA_ACS
+	uint8_t *_etext = NULL ;
+	uint8_t *_edata = NULL ;
+	uint8_t *_text = NULL ;
+	uint8_t *_data = NULL ;
+#endif
 	uintptr_t text = (uintptr_t)&_text, etext = __ALIGN((uintptr_t)&_etext, 4096);
 	uintptr_t data = (uintptr_t)&_data, edata = __ALIGN((uintptr_t)&_edata, 4096);
 

--- a/lib/arm64/asm/page.h
+++ b/lib/arm64/asm/page.h
@@ -10,7 +10,11 @@
  * This work is licensed under the terms of the GNU GPL, version 2.
  */
 
+#ifndef BSA_ACS
 #include <config.h>
+#else
+#define CONFIG_PAGE_SIZE _AC(4096, UL)
+#endif
 #include <linux/const.h>
 #include <libcflat.h>
 

--- a/lib/arm64/processor.c
+++ b/lib/arm64/processor.c
@@ -107,12 +107,13 @@ static void bad_exception(enum vector v, struct pt_regs *regs,
 	unsigned long far;
 	bool far_valid = get_far(esr, &far);
 	unsigned int ec = esr >> ESR_EL1_EC_SHIFT;
+#ifndef BSA_ACS
 	uintptr_t text = (uintptr_t)&_text;
 
 	printf("Load address: %" PRIxPTR "\n", text);
 	printf("PC: %" PRIxPTR " PC offset: %" PRIxPTR "\n",
 	       (uintptr_t)regs->pc, (uintptr_t)regs->pc - text);
-
+#endif
 	if (bad_vector) {
 		if (v < VECTOR_MAX)
 			printf("Unhandled vector %d (%s)\n", v,

--- a/lib/errata.h
+++ b/lib/errata.h
@@ -6,7 +6,10 @@
  */
 #ifndef _ERRATA_H_
 #define _ERRATA_H_
+
+#ifndef BSA_ACS
 #include "config.h"
+#endif
 
 #ifndef CONFIG_ERRATA_FORCE
 #define CONFIG_ERRATA_FORCE 0

--- a/lib/libcflat.h
+++ b/lib/libcflat.h
@@ -36,10 +36,12 @@
 #define __ALIGN(x, a)		__ALIGN_MASK(x, (typeof(x))(a) - 1)
 #define ALIGN(x, a)		__ALIGN((x), (a))
 #define ALIGN_DOWN(x, a)	__ALIGN((x) - ((a) - 1), (a))
-#define IS_ALIGNED(x, a)	(((x) & ((typeof(x))(a) - 1)) == 0)
 
+#ifndef BSA_ACS
+#define IS_ALIGNED(x, a)	(((x) & ((typeof(x))(a) - 1)) == 0)
 #define MIN(a, b)		((a) < (b) ? (a) : (b))
 #define MAX(a, b)		((a) > (b) ? (a) : (b))
+#endif
 
 typedef uint8_t		u8;
 typedef int8_t		s8;
@@ -119,7 +121,9 @@ bool simple_glob(const char *text, const char *pattern);
 extern void dump_stack(void);
 extern void dump_frame_stack(const void *instruction, const void *frame);
 
+#ifndef BSA_ACS
 #define ARRAY_SIZE(_a) (sizeof(_a)/sizeof((_a)[0]))
+#endif
 
 #define container_of(ptr, type, member) ({				\
 	const typeof( ((type *)0)->member ) *__mptr = (ptr);		\

--- a/lib/linux/efi.h
+++ b/lib/linux/efi.h
@@ -10,6 +10,7 @@
 # define __packed		__attribute__((__packed__))
 #endif
 
+#ifndef BSA_ACS
 #define BITS_PER_LONG 64
 
 #define EFI_SUCCESS		0
@@ -26,6 +27,8 @@
 #define EFI_TIMEOUT		(18 | (1UL << (BITS_PER_LONG-1)))
 #define EFI_ABORTED		(21 | (1UL << (BITS_PER_LONG-1)))
 #define EFI_SECURITY_VIOLATION	(26 | (1UL << (BITS_PER_LONG-1)))
+
+#endif
 
 typedef unsigned long efi_status_t;
 typedef u8 efi_bool_t;
@@ -105,6 +108,7 @@ typedef	struct {
 #define EFI_PERSISTENT_MEMORY		14
 #define EFI_MAX_MEMORY_TYPE		15
 
+#ifndef BSA_ACS
 /* Attribute values: */
 #define EFI_MEMORY_UC		((u64)0x0000000000000001ULL)	/* uncached */
 #define EFI_MEMORY_WC		((u64)0x0000000000000002ULL)	/* write-coalescing */
@@ -127,6 +131,7 @@ typedef	struct {
 #define EFI_PAGE_SIZE		(1UL << EFI_PAGE_SHIFT)
 #define EFI_PAGES_MAX		(U64_MAX >> EFI_PAGE_SHIFT)
 
+#endif
 typedef struct {
 	u32 type;
 	u32 pad;
@@ -167,10 +172,12 @@ int __efi_capsule_setup_info(struct capsule_info *cap_info);
 /*
  * Types and defines for Time Services
  */
+
+#ifndef BSA_ACS
 #define EFI_TIME_ADJUST_DAYLIGHT 0x1
 #define EFI_TIME_IN_DAYLIGHT     0x2
 #define EFI_UNSPECIFIED_TIMEZONE 0x07ff
-
+#endif
 typedef struct {
 	u16 year;
 	u8 month;
@@ -195,12 +202,13 @@ typedef void *efi_event_t;
 /* Note that notifications won't work in mixed mode */
 typedef void (__efiapi *efi_event_notify_t)(efi_event_t, void *);
 
+#ifndef BSA_ACS
 typedef enum {
 	EfiTimerCancel,
 	EfiTimerPeriodic,
 	EfiTimerRelative
 } EFI_TIMER_DELAY;
-
+#endif
 /*
  * EFI Device Path information
  */
@@ -331,9 +339,10 @@ typedef struct {
 /*
  * EFI Runtime Services table
  */
+#ifndef BSA_ACS
 #define EFI_RUNTIME_SERVICES_SIGNATURE ((u64)0x5652453544e5552ULL)
 #define EFI_RUNTIME_SERVICES_REVISION  0x00010000
-
+#endif
 typedef efi_status_t efi_get_time_t (efi_time_t *tm, efi_time_cap_t *tc);
 typedef efi_status_t efi_set_time_t (efi_time_t *tm);
 typedef efi_status_t efi_get_wakeup_time_t (efi_bool_t *enabled, efi_bool_t *pending,
@@ -386,8 +395,9 @@ typedef struct {
 	efi_query_variable_info_t __efiapi	*query_variable_info;
 } efi_runtime_services_t;
 
+#ifndef BSA_ACS
 #define EFI_SYSTEM_TABLE_SIGNATURE ((u64)0x5453595320494249ULL)
-
+#endif
 #define EFI_2_30_SYSTEM_TABLE_REVISION  ((2 << 16) | (30))
 #define EFI_2_20_SYSTEM_TABLE_REVISION  ((2 << 16) | (20))
 #define EFI_2_10_SYSTEM_TABLE_REVISION  ((2 << 16) | (10))


### PR DESCRIPTION

 - the compiled library is used to run memory model consistency tests in UEFI integrated with BSA-ACS
 - added few conditional compilation based on target.